### PR TITLE
removed --save from yarn command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ npm install gentelella --save
 **yarn**
 
 ```
-yarn add gentelella --save
+yarn add gentelella
 ```
 ## How to contribute
 To contribute, please ensure that you have stable [Node.js](https://nodejs.org/) and [npm](https://npmjs.com) installed.


### PR DESCRIPTION
IIRC, it was announced as one of improvements of yarn over npm, that `--save` is not required. Upon adding a package, yarn automatically saves it in `packages.json` and `yarn.lock`.

At least the [docs of yarn](https://yarnpkg.com/en/docs/managing-dependencies) do not use the `--save` option and `yarn help add | grep -- '--save'` returns nothing (i.e. the option does not even exist).