### PR TITLE
Emit a root redirect in the build so deploy roots stop 404ing

### DIFF
--- a/scripts/deploy-preview.sh
+++ b/scripts/deploy-preview.sh
@@ -33,13 +33,9 @@ BASE_PATH="/theme/$SLUG/" npm run build
 # Strip dev artifacts.
 rm -f dist/stats.html
 
-# Root redirect so the bare slug URL navigates to the dashboard.
-cat > dist/index.html <<'EOF'
-<!DOCTYPE html>
-<meta http-equiv="refresh" content="0;url=production/index.html">
-<link rel="canonical" href="production/index.html">
-<title>Gentelella v4</title>
-EOF
+# The root redirect (dist/index.html -> production/index.html) is emitted by
+# rootRedirectPlugin in vite.config.js, so every consumer of dist/ gets a front
+# door — this bucket, GitHub Pages, and `npm run preview` alike.
 
 LONG_CACHE='Cache-Control: public, max-age=31536000, immutable'
 SHORT_CACHE='Cache-Control: public, max-age=60, must-revalidate'

--- a/vite.config.js
+++ b/vite.config.js
@@ -21,6 +21,31 @@ function discoverEntries() {
   return out;
 }
 
+// Emit a root index.html that forwards to the dashboard. Entry pages all live
+// under production/, so without this the bare deploy root (GitHub Pages, R2,
+// `npm run preview`) has no front door and 404s. The redirect target is
+// relative, so it resolves the same whether the site is served from / or from
+// a subpath like /gentelella/ or /theme/gentelella/.
+function rootRedirectPlugin() {
+  return {
+    name: 'gentelella-root-redirect',
+    apply: 'build',
+    generateBundle() {
+      this.emitFile({
+        type: 'asset',
+        fileName: 'index.html',
+        source: [
+          '<!DOCTYPE html>',
+          '<meta http-equiv="refresh" content="0;url=production/index.html">',
+          '<link rel="canonical" href="production/index.html">',
+          '<title>Gentelella v4</title>',
+          ''
+        ].join('\n')
+      });
+    }
+  };
+}
+
 // Inject sidebar/topbar/footer into pages with body[data-shell="admin"] at
 // dev/build time so the shell paints on the first frame (no FOUC). The
 // runtime mountShell() detects already-injected shells and skips re-rendering;
@@ -112,7 +137,7 @@ export default defineConfig(({ command }) => ({
   root: '.',
   base: command === 'serve' ? '/' : (process.env.BASE_PATH ?? '/'),
   publicDir: 'public',
-  plugins: [shellInjectionPlugin()],
+  plugins: [shellInjectionPlugin(), rootRedirectPlugin()],
   logLevel: 'info',
   clearScreen: false,
   build: {


### PR DESCRIPTION
## The bug

`https://colorlibhq.github.io/gentelella/` currently serves a **404**, while `/production/index.html` under it serves fine.

| URL | Before |
|---|---|
| `colorlibhq.github.io/gentelella/` | **404** |
| `colorlibhq.github.io/gentelella/production/index.html` | 200 |
| `preview.colorlib.com/theme/gentelella/` | 200 |

## Why

Every entry page lives under `production/`, so `npm run build` never produces a root `dist/index.html`.

The R2 path papered over this by writing the stub itself in `scripts/deploy-preview.sh` — which is why the preview host has a working front door and Pages doesn't. The Pages workflow uploads `dist/` straight from `npm run build`, so it never got one.

## The fix

Move the stub into `rootRedirectPlugin` in `vite.config.js` so it's emitted as part of the build, and drop the now-duplicated copy from the deploy script. One source of truth; every consumer of `dist/` gets a front door — Pages, R2, and `npm run preview` alike.

The redirect target is relative, so it resolves identically at `/`, `/gentelella/`, and `/theme/gentelella/`. No `base` handling needed.

## Verification

Built with `BASE_PATH=/gentelella/` exactly as the workflow does, served under that subpath, and driven in a browser:

```
/gentelella/                       200
/gentelella/production/index.html  200

landed on  : /gentelella/production/index.html
title      : Dashboard | Gentelella 2026 v4
shell      : rendered
failed reqs: none
```

`npm run lint` passes. Deploy-script behaviour is unchanged — pass 2's `--include "*.html"` already covers the root stub, so it keeps its short-cache header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)