### PR TITLE
Point the theme and playground demo links at production/

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Perfect for: **SaaS dashboards**, **CRM**, **ERP**, **internal admin panels**, *
 
 ## Features
 
-- **🎨 Live theme generator** — pick a primary color, watch every chart, button, badge, and link restyle in real time. Copy or download the generated SCSS tokens. Demo: [theme.html](https://preview.colorlib.com/theme/gentelella/theme.html)
-- **🧪 Component playground** — every reusable component on one page, side-by-side with its **exact HTML** and a Copy button. Demo: [playground.html](https://preview.colorlib.com/theme/gentelella/playground.html)
+- **🎨 Live theme generator** — pick a primary color, watch every chart, button, badge, and link restyle in real time. Copy or download the generated SCSS tokens. Demo: [theme.html](https://preview.colorlib.com/theme/gentelella/production/theme.html)
+- **🧪 Component playground** — every reusable component on one page, side-by-side with its **exact HTML** and a Copy button. Demo: [playground.html](https://preview.colorlib.com/theme/gentelella/production/playground.html)
 - **⌘K command palette** — fuzzy search across all 58 pages and inline actions
 - **📬 Real inbox client** — folders, reader pane, compose modal, reply/forward, J/K/R/S/# keyboard shortcuts, search across the active folder
 - **📱 PWA** — installable on macOS / Windows / iOS / Android, offline shell, service worker
@@ -378,7 +378,7 @@ Type declarations for the public JS surface ship in [`types/gentelella.d.ts`](ty
 
 ### Markup helpers
 
-For pages that build content from data (orders rows, inbox threads, kanban cards), [`src/v4/markup.js`](src/v4/markup.js) exposes pure string-returning helpers — `statTile()`, `statusBadge()`, `customerCell()`, `activityItem()`, `visitorRow()`, `emptyState()`, `banner()`, `skeletonRows()`, plus `escapeHtml()`. Live examples on the [Playground](https://preview.colorlib.com/theme/gentelella/playground.html#helpers-intro). Static pages keep their hand-written HTML — these are for JS-driven content where the boilerplate adds up.
+For pages that build content from data (orders rows, inbox threads, kanban cards), [`src/v4/markup.js`](src/v4/markup.js) exposes pure string-returning helpers — `statTile()`, `statusBadge()`, `customerCell()`, `activityItem()`, `visitorRow()`, `emptyState()`, `banner()`, `skeletonRows()`, plus `escapeHtml()`. Live examples on the [Playground](https://preview.colorlib.com/theme/gentelella/production/playground.html#helpers-intro). Static pages keep their hand-written HTML — these are for JS-driven content where the boilerplate adds up.
 
 ## SEO and metadata
 


### PR DESCRIPTION
Both demo links in the README dropped the `production/` path segment, so the two features the README calls out by name led to 404s.

| Link | Before | After |
|---|---|---|
| `/theme/gentelella/theme.html` | **404** | — |
| `/theme/gentelella/playground.html` | **404** | — |
| `/theme/gentelella/production/theme.html` | — | 200 |
| `/theme/gentelella/production/playground.html` | — | 200 |

Three occurrences fixed: the theme generator bullet, the component playground bullet, and the `markup.js` helpers link (which also carries a `#helpers-intro` anchor — verified present on the page).

Same root cause as #1001: every entry page lives under `production/`. The hero link on line 35 and the inbox/kanban links already had it right; this brings the remaining three in line.

I swept all 61 external links across `README.md` and `docs/*.md` — these three were the only genuine breaks. Two apparent failures were false positives worth noting: `/stargazers` 404s anonymously for `facebook/react` and `vitejs/vite` too (GitHub gates that page behind auth), and npmjs.com returns 403 to non-browser user agents while the package resolves fine to 4.1.1 via the registry API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)