### PR TITLE
Add RTL support via CSS logical properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Perfect for: **SaaS dashboards**, **CRM**, **ERP**, **internal admin panels**, *
 - **📱 PWA** — installable on macOS / Windows / iOS / Android, offline shell, service worker
 - **↔️ Sidebar rail mode** — desktop hamburger collapses sidebar to icon-only with hover tooltips and click-to-flyout submenus
 - **🌗 Dark mode** — `prefers-color-scheme` aware, pre-paint script prevents flash, manual toggle persists in `localStorage`
+- **↔️ RTL support** — Arabic / Hebrew / Persian layouts via `<html dir="rtl">`, built on CSS logical properties (no mirrored stylesheet to maintain). See [docs/rtl.md](docs/rtl.md)
 - **♿ Accessibility** — skip-link, keyboard focus rings, ARIA labels on interactive controls, semantic landmarks, screen-reader-friendly DataTables
 
 ## What you get
@@ -425,7 +426,6 @@ Shipped in `4.0.0` — full list in [`changelog.md`](changelog.md). Still planne
 - **JSON-LD structured data** on landing + marketing pages
 - **`sitemap.xml`** generator (auto-built from `production/*.html`)
 - **Per-page chart-type tree-shaking** to slim the ECharts vendor chunk
-- **RTL support** (logical-properties pass)
 - **i18n extraction pattern**
 
 Want any of these prioritized? [Open an issue](https://github.com/ColorlibHQ/gentelella/issues).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -64,6 +64,7 @@
 - **📱 PWA** — 可安装到 macOS / Windows / iOS / Android，支持离线外壳与 Service Worker
 - **↔️ 侧边栏图标模式** — 桌面端点击汉堡按钮可将侧边栏收起为纯图标，悬停显示提示，点击弹出子菜单
 - **🌗 深色模式** — 自动识别 `prefers-color-scheme`，前置脚本消除闪烁，手动切换结果保存在 `localStorage`
+- **↔️ RTL 支持** — 通过 `<html dir="rtl">` 支持阿拉伯语 / 希伯来语 / 波斯语布局，基于 CSS 逻辑属性实现（无需维护镜像样式表）。详见 [docs/rtl.md](docs/rtl.md)
 - **♿ 无障碍** — 跳转链接、键盘焦点样式、交互控件的 ARIA 标签、语义化地标区域，以及对屏幕阅读器友好的 DataTables
 
 ## 包含内容
@@ -366,7 +367,6 @@ npm run new -- reports --title "Reports" --pretitle "Admin" \
 - 落地页与营销页的 **JSON-LD 结构化数据**
 - **`sitemap.xml`** 生成器（依据 `production/*.html` 自动生成）
 - **按页面对图表类型做 tree-shaking**，进一步精简 ECharts 依赖块
-- **RTL 支持**（逻辑属性改造）
 - **i18n 文案提取方案**
 
 希望优先实现其中某一项？欢迎[提交 issue](https://github.com/ColorlibHQ/gentelella/issues)。

--- a/docs/rtl.md
+++ b/docs/rtl.md
@@ -1,0 +1,79 @@
+# RTL (right-to-left)
+
+Gentelella v4 supports right-to-left layouts for Arabic, Hebrew, Persian, and Urdu.
+
+## Turning it on
+
+Set `dir` on the root element:
+
+```html
+<html lang="ar" dir="rtl">
+```
+
+That's the whole API. Every layout, spacing, and alignment rule flips.
+
+To let users switch at runtime — and have the choice survive a reload without a flash of the wrong direction — write it to `localStorage` under the `dir` key:
+
+```js
+localStorage.setItem('dir', 'rtl');
+document.documentElement.setAttribute('dir', 'rtl');
+```
+
+The pre-paint script in `vite.config.js` reads that key and applies `dir` to `<html>` before the body renders, exactly as it does for the theme. Valid values are `'rtl'` and `'ltr'`; anything else is ignored and the document's own `dir` stands.
+
+## How it works
+
+The styling is built on **CSS logical properties**, so direction is handled by the browser rather than by a mirrored stylesheet:
+
+| Physical | Logical |
+| --- | --- |
+| `margin-left` / `margin-right` | `margin-inline-start` / `margin-inline-end` |
+| `padding-left` / `padding-right` | `padding-inline-start` / `padding-inline-end` |
+| `border-left` / `border-right` | `border-inline-start` / `border-inline-end` |
+| `left:` / `right:` | `inset-inline-start` / `inset-inline-end` |
+| `text-align: left` / `right` | `text-align: start` / `end` |
+| `border-top-left-radius` (and friends) | `border-start-start-radius` (and friends) |
+
+There is no separate `rtl.css` to keep in sync, and no build step that mirrors a stylesheet — one set of rules serves both directions.
+
+[`_rtl.scss`](../src/scss/v4/_rtl.scss) exists only for the handful of properties with no logical equivalent:
+
+- **`translateX()`** — transforms are physical by definition (sidebar drawer, slide-out drawer, switch and toggle knobs, rail flyout labels)
+- **`background-position`** — the native select arrow
+- **`box-shadow`** offsets — the drawer's edge shadow
+- **Chevrons** that point along the inline axis
+
+## Writing new styles
+
+Use logical properties and new components work in both directions for free:
+
+```scss
+.my-card {
+  padding-inline-start: 16px;   // not padding-left
+  border-inline-end: 1px solid var(--border);
+  text-align: start;            // not text-align: left
+}
+```
+
+Two patterns are worth knowing:
+
+**Centring is direction-neutral — don't convert it.** `left: 50%` paired with `translateX(-50%)` is correct in both directions. Rewriting it to `inset-inline-start: 50%` breaks RTL, because the offset flips while the transform doesn't.
+
+```scss
+.centred {
+  left: 50%;                    // stays physical — this is correct
+  transform: translateX(-50%);
+}
+```
+
+**Vertical rotation is direction-neutral too.** A chevron that points *down* when open should not be overridden for RTL; only the closed state, which points along the inline axis, needs mirroring.
+
+## What isn't mirrored
+
+- **Charts.** ECharts renders its own canvas; axis and legend placement is unchanged. Pass ECharts its own options if you need mirrored axes.
+- **Latin text inside an RTL page.** English strings in an RTL container reorder per the Unicode bidi algorithm (`4 of 6 remaining` renders as `of 6 remaining 4`). That's correct bidi behaviour, not a layout bug — it resolves once the content is genuinely RTL. Wrap mixed-direction runs in `<bdi>` or an element with an explicit `dir` if you need to pin them.
+- **Icons that aren't directional.** Only chevrons and arrows along the inline axis are flipped; a search or trash icon is not mirrored.
+
+## Verifying a change
+
+LTR rendering must not shift when logical properties are introduced — in a left-to-right document they compute identically to the physical ones they replace. The conversion in this repo was gated on exactly that: 12 representative pages screenshotted before and after and compared by hash, all pixel-identical.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -9,6 +9,7 @@ Facts that are commonly gotten wrong:
 - Current version is 4.1.1. License is MIT.
 - v4 has **no Bootstrap and no jQuery**. Gentelella v2 *was* Bootstrap-based, so older articles and answers describing it as a "Bootstrap admin template" describe v2, not v4. A migration guide is linked below.
 - There are exactly three runtime dependencies, all lazy-imported per page so pages that don't use them never load them: ECharts 6 (charts), DataTables.net 3 (tables), Leaflet 1.9 (maps).
+- Right-to-left layouts are supported via `<html dir="rtl">`, built on CSS logical properties.
 - Styling is SCSS compiled to CSS, themed with CSS custom properties. Light and dark themes ship built in; dark mode is applied pre-paint so it never flashes light.
 - Pages are static HTML under `production/`. There is no server, no database, and no build-time templating language.
 
@@ -30,6 +31,7 @@ Install with `npm install gentelella`, or load from the jsDelivr CDN. Run `npm r
 - [Command palette](https://raw.githubusercontent.com/ColorlibHQ/gentelella/master/docs/command-palette.md): The Cmd/Ctrl-K palette and how to register commands.
 - [Data adapter](https://raw.githubusercontent.com/ColorlibHQ/gentelella/master/docs/data-adapter.md): Swapping the demo data shim for a real API.
 - [TypeScript](https://raw.githubusercontent.com/ColorlibHQ/gentelella/master/docs/typescript.md): The bundled declarations for the public JS surface.
+- [RTL](https://raw.githubusercontent.com/ColorlibHQ/gentelella/master/docs/rtl.md): Right-to-left layouts for Arabic, Hebrew, and Persian via CSS logical properties.
 - [PWA](https://raw.githubusercontent.com/ColorlibHQ/gentelella/master/docs/pwa.md): Service worker and web app manifest.
 - [Deployment](https://raw.githubusercontent.com/ColorlibHQ/gentelella/master/docs/deployment.md): Static hosting, subpath deploys, and cache headers.
 - [Migration from v2](https://raw.githubusercontent.com/ColorlibHQ/gentelella/master/docs/migration-v2.md): Moving off the Bootstrap/jQuery v2 codebase.

--- a/src/scss/v4/_apps.scss
+++ b/src/scss/v4/_apps.scss
@@ -14,7 +14,7 @@
 }
 
 .chat-rail {
-  border-right: 1px solid var(--border-color-light);
+  border-inline-end: 1px solid var(--border-color-light);
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -61,7 +61,7 @@
   border: none;
   border-bottom: 1px solid var(--border-color-light);
   cursor: pointer;
-  text-align: left;
+  text-align: start;
   font: inherit;
   transition: background 100ms;
 }
@@ -80,7 +80,7 @@
   position: relative;
 }
 .chat-conversation .av .online {
-  position: absolute; bottom: -1px; right: -1px;
+  position: absolute; bottom: -1px; inset-inline-end: -1px;
   width: 9px; height: 9px;
   background: var(--green);
   border: 2px solid var(--bg-surface);
@@ -192,12 +192,12 @@
   background: var(--bg-surface);
   color: var(--text);
   border: 1px solid var(--border-color);
-  border-bottom-left-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .chat-bubble.mine .bubble {
   background: var(--primary);
   color: white;
-  border-bottom-right-radius: 4px;
+  border-end-end-radius: 4px;
 }
 .chat-bubble .meta {
   font-size: 10.5px;
@@ -470,7 +470,7 @@
 // ────────────────────────
 .notif-tabs .notif-tab-count {
   display: inline-block;
-  margin-left: 4px;
+  margin-inline-start: 4px;
   padding: 0 6px;
   background: var(--primary-lt);
   color: var(--primary);
@@ -490,7 +490,7 @@
   border: none;
   border-bottom: 1px solid var(--border-color-light);
   cursor: pointer;
-  text-align: left;
+  text-align: start;
   font: inherit;
   transition: background 100ms;
   position: relative;
@@ -500,7 +500,7 @@
 .notification-row.unread::before {
   content: '';
   position: absolute;
-  left: 8px; top: 22px;
+  inset-inline-start: 8px; top: 22px;
   width: 6px; height: 6px;
   border-radius: 50%;
   background: var(--primary);
@@ -569,7 +569,7 @@
 }
 .lock-icon {
   position: absolute;
-  bottom: -2px; right: -4px;
+  bottom: -2px; inset-inline-end: -4px;
   width: 26px; height: 26px;
   background: var(--bg-surface);
   border: 2px solid var(--bg-surface);
@@ -711,7 +711,7 @@
   font-size: 13.5px;
   font-weight: var(--font-weight-medium);
   color: var(--text);
-  text-align: left;
+  text-align: start;
   cursor: pointer;
 }
 .faq-q:hover { color: var(--primary); }
@@ -770,8 +770,8 @@
   content: '';
   position: absolute;
   top: 12px;
-  left: 12px;
-  right: 12px;
+  inset-inline-start: 12px;
+  inset-inline-end: 12px;
   height: 2px;
   background: var(--border-color-light);
   z-index: 0;
@@ -821,7 +821,7 @@
   gap: var(--space-3);
 }
 .order-info-row .label { color: var(--text-muted); }
-.order-info-row .value { color: var(--text); font-weight: var(--font-weight-medium); text-align: right; }
+.order-info-row .value { color: var(--text); font-weight: var(--font-weight-medium); text-align: end; }
 
 // ────────────────────────
 //  USER MANAGEMENT
@@ -879,7 +879,7 @@
 .gallery-svg svg { display: block; }
 .gallery-badge {
   position: absolute;
-  top: 12px; left: 12px;
+  top: 12px; inset-inline-start: 12px;
   padding: 3px 9px;
   background: var(--primary);
   color: white;
@@ -927,7 +927,7 @@
   margin-bottom: 6px;
 }
 .product-meta .rating { font-size: 12px; color: var(--yellow); font-weight: var(--font-weight-medium); }
-.product-meta .rating small { color: var(--text-muted); font-weight: normal; margin-left: 4px; }
+.product-meta .rating small { color: var(--text-muted); font-weight: normal; margin-inline-start: 4px; }
 
 .product-title {
   font-size: 22px;
@@ -1034,8 +1034,8 @@
   height: 34px;
   text-align: center;
   border: none;
-  border-left: 1px solid var(--border-color);
-  border-right: 1px solid var(--border-color);
+  border-inline-start: 1px solid var(--border-color);
+  border-inline-end: 1px solid var(--border-color);
   font: inherit;
   font-size: 13px;
   font-variant-numeric: tabular-nums;
@@ -1114,7 +1114,7 @@
   overflow: hidden;
 }
 .r-bar .fill { height: 100%; }
-.r-bar .cnt { text-align: right; }
+.r-bar .cnt { text-align: end; }
 
 .reviews-list { display: flex; flex-direction: column; gap: 18px; }
 .review { padding-bottom: 16px; border-bottom: 1px solid var(--border-color-light); }
@@ -1181,7 +1181,7 @@
   max-height: 800px;
 }
 .fm-tree-wrap {
-  border-right: 1px solid var(--border-color-light);
+  border-inline-end: 1px solid var(--border-color-light);
   display: flex;
   flex-direction: column;
   padding: 8px;
@@ -1203,7 +1203,7 @@
   font: inherit;
   font-size: 13px;
   color: var(--text-secondary);
-  text-align: left;
+  text-align: start;
   cursor: pointer;
   transition: background 100ms, color 100ms;
 }
@@ -1211,8 +1211,8 @@
 .tree-link.active { background: var(--primary-lt); color: var(--primary); font-weight: var(--font-weight-medium); }
 .tree-link svg { color: var(--text-muted); flex-shrink: 0; }
 .tree-link.active svg { color: var(--primary); }
-.tree-sub { padding-left: 24px; }
-.tree-sub-sub { padding-left: 40px; }
+.tree-sub { padding-inline-start: 24px; }
+.tree-sub-sub { padding-inline-start: 40px; }
 
 .fm-storage {
   margin-top: auto;
@@ -1301,7 +1301,7 @@
   border-radius: var(--radius);
   cursor: pointer;
   font: inherit;
-  text-align: left;
+  text-align: start;
   transition: border-color 120ms, transform 120ms, box-shadow 120ms;
 }
 .fm-grid.view-grid .fm-item {
@@ -1354,7 +1354,7 @@
 .fm-star {
   position: absolute;
   top: 6px;
-  right: 6px;
+  inset-inline-end: 6px;
   width: 22px; height: 22px;
   display: flex;
   align-items: center;
@@ -1374,7 +1374,7 @@
 .fm-item-menu {
   position: absolute;
   bottom: 6px;
-  right: 6px;
+  inset-inline-end: 6px;
   width: 22px;
   height: 22px;
   border: none;
@@ -1470,7 +1470,7 @@
   font-weight: var(--font-weight-medium);
 }
 .kanban-add {
-  margin-left: auto;
+  margin-inline-start: auto;
   width: 22px; height: 22px;
   border: none;
   background: transparent;
@@ -1509,7 +1509,7 @@
   font-size: 12.5px;
   color: var(--text-muted);
   cursor: pointer;
-  text-align: left;
+  text-align: start;
   transition: background 100ms, color 100ms;
 }
 .kanban-column-foot:hover { background: var(--bg-surface); color: var(--text); }
@@ -1603,7 +1603,7 @@
   border: 2px solid var(--bg-surface);
   flex-shrink: 0;
 }
-.kanban-avatar + .kanban-avatar { margin-left: -6px; }
+.kanban-avatar + .kanban-avatar { margin-inline-start: -6px; }
 
 .kanban-chip-group {
   display: flex;

--- a/src/scss/v4/_auth.scss
+++ b/src/scss/v4/_auth.scss
@@ -150,7 +150,7 @@
   grid-template-columns: 1fr 1fr;
   gap: var(--space-3);
   margin: 20px 0 24px;
-  text-align: left;
+  text-align: start;
   background: var(--bg-surface);
   border: 1px solid var(--border-color);
   border-radius: var(--radius);

--- a/src/scss/v4/_components.scss
+++ b/src/scss/v4/_components.scss
@@ -115,7 +115,7 @@ table.table {
   font-size: 13px;
 }
 table.table th {
-  text-align: left;
+  text-align: start;
   padding: 8px 16px;
   font-size: 11px;
   font-weight: var(--font-weight-bold);
@@ -234,7 +234,7 @@ table.table tbody tr:hover { background: var(--bg-surface-secondary); }
 .toggle::after {
   content: '';
   position: absolute;
-  top: 2px; left: 2px;
+  top: 2px; inset-inline-start: 2px;
   width: 16px; height: 16px;
   background: white;
   border-radius: 50%;
@@ -248,7 +248,7 @@ table.table tbody tr:hover { background: var(--bg-surface-secondary); }
 // ────────────────────────
 .toast-host {
   position: fixed;
-  right: 16px;
+  inset-inline-end: 16px;
   bottom: 16px;
   z-index: 1000;
   display: flex;
@@ -274,9 +274,9 @@ table.table tbody tr:hover { background: var(--bg-surface-secondary); }
   transition: opacity 180ms ease, transform 180ms cubic-bezier(0.2, 0, 0, 1);
 }
 .toast.show { opacity: 1; transform: translateY(0); }
-.toast-success { border-left: 3px solid var(--green); padding-left: 11px; }
-.toast-error   { border-left: 3px solid var(--red);   padding-left: 11px; }
-.toast-warning { border-left: 3px solid var(--yellow); padding-left: 11px; }
+.toast-success { border-inline-start: 3px solid var(--green); padding-inline-start: 11px; }
+.toast-error   { border-inline-start: 3px solid var(--red);   padding-inline-start: 11px; }
+.toast-warning { border-inline-start: 3px solid var(--yellow); padding-inline-start: 11px; }
 @media (prefers-reduced-motion: reduce) {
   .toast { transition: opacity 80ms; transform: none; }
 }
@@ -305,7 +305,7 @@ table.table tbody tr:hover { background: var(--bg-surface-secondary); }
   appearance: none;
   background: transparent;
   border: none;
-  text-align: left;
+  text-align: start;
   font: inherit;
   font-size: 13px;
   color: var(--text);
@@ -351,7 +351,7 @@ table.table tbody tr:hover { background: var(--bg-surface-secondary); }
   color: var(--primary);
 }
 .menu-panel .panel-action {
-  margin-left: auto;
+  margin-inline-start: auto;
   background: transparent;
   border: none;
   color: var(--primary);
@@ -376,7 +376,7 @@ table.table tbody tr:hover { background: var(--bg-surface-secondary); }
   border: none;
   border-bottom: 1px solid var(--border-color-light);
   cursor: pointer;
-  text-align: left;
+  text-align: start;
   font: inherit;
   transition: background 100ms;
   position: relative;
@@ -386,7 +386,7 @@ table.table tbody tr:hover { background: var(--bg-surface-secondary); }
 .menu-panel .panel-row.unread::before {
   content: '';
   position: absolute;
-  left: 5px; top: 18px;
+  inset-inline-start: 5px; top: 18px;
   width: 5px; height: 5px;
   border-radius: 50%;
   background: var(--primary);
@@ -461,7 +461,7 @@ table.table tbody tr:hover { background: var(--bg-surface-secondary); }
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  margin-left: 4px;
+  margin-inline-start: 4px;
   width: 14px;
   height: 14px;
   border-radius: 50%;
@@ -738,18 +738,18 @@ body.modal-open { overflow: hidden; }
 .btn-group { display: inline-flex; }
 .btn-group .btn {
   border-radius: 0;
-  margin-right: -1px;
+  margin-inline-end: -1px;
 }
 .btn-group .btn:hover,
 .btn-group .btn.active { z-index: 1; }
 .btn-group .btn:first-child {
-  border-top-left-radius: var(--radius-sm);
-  border-bottom-left-radius: var(--radius-sm);
+  border-start-start-radius: var(--radius-sm);
+  border-end-start-radius: var(--radius-sm);
 }
 .btn-group .btn:last-child {
-  border-top-right-radius: var(--radius-sm);
-  border-bottom-right-radius: var(--radius-sm);
-  margin-right: 0;
+  border-start-end-radius: var(--radius-sm);
+  border-end-end-radius: var(--radius-sm);
+  margin-inline-end: 0;
 }
 .btn-group .btn.active {
   background: var(--primary-lt);
@@ -787,7 +787,7 @@ body.modal-open { overflow: hidden; }
 
 .avatar-status {
   position: absolute;
-  bottom: 0; right: 0;
+  bottom: 0; inset-inline-end: 0;
   width: 28%; height: 28%;
   min-width: 6px; min-height: 6px;
   border-radius: 50%;
@@ -801,9 +801,9 @@ body.modal-open { overflow: hidden; }
 .avatar-stack { display: inline-flex; }
 .avatar-stack .avatar {
   border: 2px solid var(--bg-surface);
-  margin-left: -8px;
+  margin-inline-start: -8px;
 }
-.avatar-stack .avatar:first-child { margin-left: 0; }
+.avatar-stack .avatar:first-child { margin-inline-start: 0; }
 .avatar-stack .avatar.more {
   background: var(--bg-surface-secondary);
   color: var(--text-secondary);
@@ -856,16 +856,16 @@ body.modal-open { overflow: hidden; }
 .loading-bar::before {
   content: '';
   position: absolute;
-  top: 0; left: -40%;
+  top: 0; inset-inline-start: -40%;
   width: 40%; height: 100%;
   background: var(--primary);
   border-radius: 3px;
   animation: loading-bar-slide 1.4s ease-in-out infinite;
 }
 @keyframes loading-bar-slide {
-  0%   { left: -40%; }
-  60%  { left: 100%; }
-  100% { left: 100%; }
+  0%   { inset-inline-start: -40%; }
+  60%  { inset-inline-start: 100%; }
+  100% { inset-inline-start: 100%; }
 }
 @media (prefers-reduced-motion: reduce) { .loading-bar::before { animation-duration: 2.4s; } }
 
@@ -1199,7 +1199,7 @@ body.modal-open { overflow: hidden; }
   font-size: 13px;
   cursor: pointer;
   transition: background 100ms, color 100ms;
-  text-align: left;
+  text-align: start;
   width: 100%;
 }
 .list-group-item:last-child { border-bottom: none; }
@@ -1213,7 +1213,7 @@ body.modal-open { overflow: hidden; }
   font-weight: var(--font-weight-medium);
 }
 .list-group-item .meta {
-  margin-left: auto;
+  margin-inline-start: auto;
   color: var(--text-muted);
   font-size: 11.5px;
 }
@@ -1268,7 +1268,7 @@ kbd {
 blockquote {
   margin: 0;
   padding: 4px 16px;
-  border-left: 3px solid var(--primary);
+  border-inline-start: 3px solid var(--primary);
   font-size: 14px;
   font-style: italic;
   color: var(--text-secondary);
@@ -1409,7 +1409,7 @@ blockquote footer cite {
   font-size: 13px;
   color: var(--text);
   cursor: pointer;
-  text-align: left;
+  text-align: start;
 }
 .cmdk-item:hover,
 .cmdk-item.active {
@@ -1457,7 +1457,7 @@ blockquote footer cite {
   background: var(--bg-surface-secondary);
   border: 1px solid var(--border-color);
   border-radius: 3px;
-  margin-right: 4px;
+  margin-inline-end: 4px;
 }
 body.cmdk-open { overflow: hidden; }
 
@@ -1488,7 +1488,7 @@ body.cmdk-open { overflow: hidden; }
 }
 .accordion-summary::-webkit-details-marker { display: none; }
 .accordion-summary .chev {
-  margin-left: auto;
+  margin-inline-start: auto;
   width: 14px; height: 14px;
   color: var(--text-muted);
   transition: transform 200ms;
@@ -1519,7 +1519,7 @@ body.cmdk-open { overflow: hidden; }
 .drawer {
   position: fixed;
   top: 0;
-  right: 0;
+  inset-inline-end: 0;
   width: min(420px, 100vw);
   height: 100vh;
   background: var(--bg-surface);
@@ -1531,7 +1531,7 @@ body.cmdk-open { overflow: hidden; }
   flex-direction: column;
 }
 .drawer.open { transform: translateX(0); }
-.drawer.left { right: auto; left: 0; transform: translateX(-100%); box-shadow: 10px 0 30px rgba(0, 0, 0, 0.12); }
+.drawer.left { inset-inline-end: auto; inset-inline-start: 0; transform: translateX(-100%); box-shadow: 10px 0 30px rgba(0, 0, 0, 0.12); }
 .drawer.left.open { transform: translateX(0); }
 .drawer-header {
   display: flex;
@@ -1560,12 +1560,12 @@ body.cmdk-open { overflow: hidden; }
 // ────────────────────────
 .timeline {
   position: relative;
-  padding-left: 24px;
+  padding-inline-start: 24px;
 }
 .timeline::before {
   content: '';
   position: absolute;
-  left: 7px;
+  inset-inline-start: 7px;
   top: 6px;
   bottom: 6px;
   width: 2px;
@@ -1577,7 +1577,7 @@ body.cmdk-open { overflow: hidden; }
 .timeline-item::before {
   content: '';
   position: absolute;
-  left: -22px;
+  inset-inline-start: -22px;
   top: 4px;
   width: 12px;
   height: 12px;

--- a/src/scss/v4/_datatable.scss
+++ b/src/scss/v4/_datatable.scss
@@ -7,7 +7,7 @@ table.has-selection tbody tr:has(input[type="checkbox"]:checked) {
 .bulk-selection-count {
   font-size: 12px;
   color: var(--text-muted);
-  margin-right: 12px;
+  margin-inline-end: 12px;
 }
 .btn-sm {
   height: 28px;
@@ -58,7 +58,7 @@ table.has-selection tbody tr:has(input[type="checkbox"]:checked) {
 .dt-search::before {
   content: '';
   position: absolute;
-  left: 9px; top: 50%;
+  inset-inline-start: 9px; top: 50%;
   width: 14px; height: 14px;
   transform: translateY(-50%);
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%239ba5b1' stroke-width='1.5'%3E%3Ccircle cx='7' cy='7' r='5'/%3E%3Cpath d='M11 11l3.5 3.5'/%3E%3C/svg%3E");

--- a/src/scss/v4/_forms.scss
+++ b/src/scss/v4/_forms.scss
@@ -11,7 +11,7 @@
   color: var(--text);
   margin-bottom: 6px;
 }
-.form-label .required { color: var(--red); margin-left: 2px; }
+.form-label .required { color: var(--red); margin-inline-start: 2px; }
 .form-help {
   font-size: 11.5px;
   color: var(--text-muted);
@@ -67,7 +67,7 @@ textarea.form-control {
 select.form-control {
   appearance: none;
   -webkit-appearance: none;
-  padding-right: 32px;
+  padding-inline-end: 32px;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' fill='none' stroke='%239ba5b1' stroke-width='1.5'%3E%3Cpath d='M3 5l3 3 3-3'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: right 10px center;
@@ -110,7 +110,7 @@ select.form-control {
   top: 50%; left: 50%;
   transform: translate(-50%, -55%) rotate(45deg);
   width: 4px; height: 8px;
-  border-right: 1.5px solid white;
+  border-inline-end: 1.5px solid white;
   border-bottom: 1.5px solid white;
 }
 .form-check input[type="radio"]:checked::after {
@@ -141,10 +141,10 @@ select.form-control {
 .input-group {
   position: relative;
 }
-.input-group .form-control { padding-left: 36px; }
+.input-group .form-control { padding-inline-start: 36px; }
 .input-group .input-icon {
   position: absolute;
-  left: 11px; top: 50%;
+  inset-inline-start: 11px; top: 50%;
   transform: translateY(-50%);
   width: 14px; height: 14px;
   color: var(--text-muted);
@@ -192,11 +192,11 @@ select.form-control {
   color: var(--text-muted);
   background: var(--bg-surface-secondary);
   white-space: nowrap;
-  border-left: 1px solid var(--border-color);
+  border-inline-start: 1px solid var(--border-color);
 }
 .input-affix .affix.prefix {
-  border-left: 0;
-  border-right: 1px solid var(--border-color);
+  border-inline-start: 0;
+  border-inline-end: 1px solid var(--border-color);
 }
 
 // ────────────────────────
@@ -251,7 +251,7 @@ select.form-control {
 .switch .track::before {
   content: '';
   position: absolute;
-  left: 2px; top: 2px;
+  inset-inline-start: 2px; top: 2px;
   width: 16px; height: 16px;
   background: white;
   border-radius: 50%;
@@ -279,7 +279,7 @@ select.form-control {
   color: var(--text);
   font-weight: var(--font-weight-medium);
   min-width: 40px;
-  text-align: right;
+  text-align: end;
   font-variant-numeric: tabular-nums;
 }
 input[type="range"].slider {
@@ -441,7 +441,7 @@ input[type="range"].slider:focus-visible {
 }
 .search-suggest-row:last-child { border-bottom: 0; }
 .search-suggest-row:hover { background: var(--bg-surface-secondary); }
-.search-suggest-row .meta { margin-left: auto; font-size: 11px; color: var(--text-muted); }
+.search-suggest-row .meta { margin-inline-start: auto; font-size: 11px; color: var(--text-muted); }
 .search-suggest-row mark {
   background: var(--yellow-lt);
   color: var(--text);
@@ -524,7 +524,7 @@ input[type="range"].slider:focus-visible {
   font-weight: var(--font-weight-medium);
   color: var(--text);
   background: var(--bg-surface-secondary);
-  border-right: 1px solid var(--border-color);
+  border-inline-end: 1px solid var(--border-color);
   cursor: pointer;
 }
 .file-input-name {
@@ -623,7 +623,7 @@ input[type="range"].slider:focus-visible {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%237e8896' stroke-width='1.5'%3E%3Crect x='3' y='4' width='18' height='16' rx='2'/%3E%3Cpath d='M3 10h18M8 4v6M16 4v6'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: right 12px center;
-  padding-right: 36px;
+  padding-inline-end: 36px;
 }
 .dr-popover {
   background: var(--bg-surface);
@@ -640,7 +640,7 @@ input[type="range"].slider:focus-visible {
   flex-direction: column;
   gap: 2px;
   padding: 14px 8px 14px 14px;
-  border-right: 1px solid var(--border-color-light);
+  border-inline-end: 1px solid var(--border-color-light);
   background: var(--bg-surface-secondary);
   min-width: 140px;
 }
@@ -651,7 +651,7 @@ input[type="range"].slider:focus-visible {
   font: inherit;
   font-size: 12.5px;
   color: var(--text-secondary);
-  text-align: left;
+  text-align: start;
   border-radius: var(--radius-sm);
   cursor: pointer;
 }
@@ -719,8 +719,8 @@ input[type="range"].slider:focus-visible {
   font-weight: 600;
   border-radius: 50%;
 }
-.dr-cell.range-start { border-top-right-radius: 0; border-bottom-right-radius: 0; }
-.dr-cell.range-end   { border-top-left-radius: 0;  border-bottom-left-radius: 0; }
+.dr-cell.range-start { border-start-end-radius: 0; border-end-end-radius: 0; }
+.dr-cell.range-end   { border-start-start-radius: 0;  border-end-start-radius: 0; }
 .dr-footer {
   margin-top: 12px;
   padding-top: 12px;
@@ -733,7 +733,7 @@ input[type="range"].slider:focus-visible {
 .dr-summary { font-size: 12px; color: var(--text-secondary); font-variant-numeric: tabular-nums; }
 @media (max-width: 600px) {
   .dr-popover { flex-direction: column; }
-  .dr-presets { flex-direction: row; flex-wrap: wrap; min-width: 0; border-right: 0; border-bottom: 1px solid var(--border-color-light); padding: 10px; }
+  .dr-presets { flex-direction: row; flex-wrap: wrap; min-width: 0; border-inline-end: 0; border-bottom: 1px solid var(--border-color-light); padding: 10px; }
   .dr-months { flex-direction: column; gap: var(--space-4); }
 }
 
@@ -796,8 +796,8 @@ input[type="range"].slider:focus-visible {
 }
 .rt-editor h2 { font-size: 17px; font-weight: 600; margin: 12px 0 6px; }
 .rt-editor blockquote {
-  border-left: 3px solid var(--primary);
-  padding-left: 12px;
+  border-inline-start: 3px solid var(--primary);
+  padding-inline-start: 12px;
   margin: 8px 0;
   color: var(--text-secondary);
 }
@@ -811,7 +811,7 @@ input[type="range"].slider:focus-visible {
   margin: 8px 0;
   overflow-x: auto;
 }
-.rt-editor ul, .rt-editor ol { padding-left: 22px; margin: 6px 0; }
+.rt-editor ul, .rt-editor ol { padding-inline-start: 22px; margin: 6px 0; }
 .rt-editor a { color: var(--primary); text-decoration: underline; }
 
 // ────────────────────────
@@ -874,7 +874,7 @@ input[type="range"].slider:focus-visible {
   padding: 4px 6px;
 }
 .ms-chev {
-  margin-left: auto;
+  margin-inline-start: auto;
   color: var(--text-muted);
   flex-shrink: 0;
   transition: transform 150ms;
@@ -883,8 +883,8 @@ input[type="range"].slider:focus-visible {
 .ms-menu {
   position: absolute;
   top: calc(100% + 4px);
-  left: 0;
-  right: 0;
+  inset-inline-start: 0;
+  inset-inline-end: 0;
   z-index: 50;
   max-height: 220px;
   overflow-y: auto;
@@ -897,7 +897,7 @@ input[type="range"].slider:focus-visible {
 .ms-option {
   display: block;
   width: 100%;
-  text-align: left;
+  text-align: start;
   padding: 7px 10px;
   background: transparent;
   border: 0;

--- a/src/scss/v4/_layout.scss
+++ b/src/scss/v4/_layout.scss
@@ -6,7 +6,7 @@
 .skip-link {
   position: fixed;
   top: 8px;
-  left: 8px;
+  inset-inline-start: 8px;
   z-index: 200;
   padding: 8px 14px;
   background: var(--primary);
@@ -41,7 +41,7 @@
 // ────────────────────────
 .sidebar {
   position: fixed;
-  left: 0; top: 0; bottom: 0;
+  inset-inline-start: 0; top: 0; bottom: 0;
   width: var(--sidebar-w);
   background: var(--sidebar-bg);
   z-index: 100;
@@ -81,7 +81,7 @@
   font-weight: 400;
   color: var(--sidebar-text);
   font-size: 13px;
-  margin-left: 2px;
+  margin-inline-start: 2px;
 }
 
 .sidebar-nav {
@@ -134,7 +134,7 @@
 }
 .nav-link:hover .icon, .nav-link.active .icon { opacity: 0.85; }
 .nav-link .badge {
-  margin-left: auto;
+  margin-inline-start: auto;
   font-size: 10px;
   font-weight: 600;
   padding: 1px 6px;
@@ -159,12 +159,12 @@
   border: 0;
   font: inherit;
   width: 100%;
-  text-align: left;
+  text-align: start;
   cursor: pointer;
 }
 .nav-toggle .nav-text { flex: 1; }
 .nav-chev {
-  margin-left: auto;
+  margin-inline-start: auto;
   opacity: 0.55;
   transition: transform 200ms cubic-bezier(0.2, 0, 0, 1), opacity 120ms;
   flex-shrink: 0;
@@ -197,7 +197,7 @@
 .nav-tree .nav-sub > .nav-sub-inner::before {
   content: '';
   position: absolute;
-  left: 19px;
+  inset-inline-start: 19px;
   top: 4px;
   bottom: 4px;
   width: 1px;
@@ -225,7 +225,7 @@
 .nav-sublink::before {
   content: '';
   position: absolute;
-  left: -9px;
+  inset-inline-start: -9px;
   top: 50%;
   width: 8px;
   height: 1px;
@@ -244,10 +244,10 @@
   background: var(--sidebar-active);
   font-weight: var(--font-weight-medium);
   // Active rail tick becomes primary teal and slightly bolder.
-  &::before { background: var(--primary); width: 12px; left: -13px; }
+  &::before { background: var(--primary); width: 12px; inset-inline-start: -13px; }
 }
 .nav-sublink .badge {
-  margin-left: auto;
+  margin-inline-start: auto;
   font-size: 10px;
   font-weight: 600;
   padding: 1px 6px;
@@ -281,7 +281,7 @@
   position: relative;
 }
 .sidebar-user .avatar .online {
-  position: absolute; bottom: -1px; right: -1px;
+  position: absolute; bottom: -1px; inset-inline-end: -1px;
   width: 8px; height: 8px;
   background: var(--green);
   border: 2px solid var(--sidebar-bg);
@@ -320,8 +320,8 @@
 .topbar {
   position: fixed;
   top: 0;
-  left: var(--sidebar-w);
-  right: 0;
+  inset-inline-start: var(--sidebar-w);
+  inset-inline-end: 0;
   height: 56px;
   background: rgba(255,255,255,0.85);
   backdrop-filter: blur(12px);
@@ -402,14 +402,14 @@
 }
 .search-box .s-icon {
   position: absolute;
-  left: 9px; top: 50%;
+  inset-inline-start: 9px; top: 50%;
   transform: translateY(-50%);
   width: 14px; height: 14px;
   color: var(--text-muted);
 }
 .search-box kbd {
   position: absolute;
-  right: 6px; top: 50%;
+  inset-inline-end: 6px; top: 50%;
   transform: translateY(-50%);
   padding: 0 5px;
   font-family: inherit;
@@ -438,7 +438,7 @@
   width: auto; height: 32px;
   padding: 0 12px;
   gap: 6px;
-  margin-right: 6px;
+  margin-inline-end: 6px;
   font-size: 13px; font-weight: 500;
   text-decoration: none;
   color: var(--primary);
@@ -451,7 +451,7 @@
 }
 .tb-btn.tb-docs svg { width: 15px; height: 15px; }
 .tb-btn .dot {
-  position: absolute; top: 6px; right: 6px;
+  position: absolute; top: 6px; inset-inline-end: 6px;
   width: 6px; height: 6px;
   background: var(--red);
   border: 1.5px solid white;
@@ -467,7 +467,7 @@
   font-size: 11px;
   font-weight: 600;
   color: white;
-  margin-left: 6px;
+  margin-inline-start: 6px;
   cursor: pointer;
   padding: 0;
   transition: transform 120ms;
@@ -478,7 +478,7 @@
 //  MAIN LAYOUT
 // ────────────────────────
 .main {
-  margin-left: var(--sidebar-w);
+  margin-inline-start: var(--sidebar-w);
   padding-top: 56px;
   min-height: 100vh;
   transition: margin-left 220ms cubic-bezier(0.2, 0, 0, 1);
@@ -564,8 +564,8 @@
     will-change: transform;
   }
   .sidebar.open { transform: translateX(0); }
-  .main { margin-left: 0; }
-  .topbar { left: 0; padding: 0 12px; }
+  .main { margin-inline-start: 0; }
+  .topbar { inset-inline-start: 0; padding: 0 12px; }
   // The 240px search box, breadcrumb, and notification/message buttons can't
   // coexist with a 32px avatar inside a 375px viewport without forcing the
   // layout viewport to scale. Drop the wide pieces; cmd-K still works for
@@ -632,7 +632,7 @@
   body.sidebar-rail .nav-link[data-rail-label]::after {
     content: attr(data-rail-label);
     position: absolute;
-    left: calc(100% + 12px);
+    inset-inline-start: calc(100% + 12px);
     top: 50%;
     transform: translateY(-50%) translateX(-4px);
     background: var(--text);

--- a/src/scss/v4/_pages.scss
+++ b/src/scss/v4/_pages.scss
@@ -12,7 +12,7 @@
   border-top: 1px solid var(--border-color-light);
 }
 .pagination .page-info {
-  margin-right: auto;
+  margin-inline-end: auto;
   font-size: 12px;
   color: var(--text-muted);
 }
@@ -192,7 +192,7 @@
   position: relative;
 }
 .inbox-sidebar {
-  border-right: 1px solid var(--border-color-light);
+  border-inline-end: 1px solid var(--border-color-light);
   padding: 12px 8px;
   overflow-y: auto;
 }
@@ -220,7 +220,7 @@
 .inbox-folder:hover { background: var(--bg-surface-secondary); color: var(--text); text-decoration: none; }
 .inbox-folder.active { background: var(--primary-lt); color: var(--primary); font-weight: var(--font-weight-medium); }
 .inbox-folder .count {
-  margin-left: auto;
+  margin-inline-start: auto;
   font-size: 11px;
   color: var(--text-muted);
   background: var(--bg-surface-secondary);
@@ -240,7 +240,7 @@
 
 // List pane (middle column)
 .inbox-list-pane {
-  border-right: 1px solid var(--border-color-light);
+  border-inline-end: 1px solid var(--border-color-light);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -286,8 +286,8 @@
 .inbox-item.unread .subject { color: var(--text); font-weight: var(--font-weight-bold); }
 .inbox-item.selected {
   background: var(--primary-lt);
-  border-left: 2px solid var(--primary);
-  padding-left: 10px;
+  border-inline-start: 2px solid var(--primary);
+  padding-inline-start: 10px;
 }
 .inbox-item-body { min-width: 0; }
 .inbox-item .sender { font-size: 12.5px; font-weight: var(--font-weight-medium); color: var(--text-secondary); margin-bottom: 1px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -309,7 +309,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.inbox-item .meta { text-align: right; font-size: 11px; color: var(--text-muted); white-space: nowrap; padding-top: 2px; }
+.inbox-item .meta { text-align: end; font-size: 11px; color: var(--text-muted); white-space: nowrap; padding-top: 2px; }
 .inbox-star-btn {
   width: 22px;
   height: 22px;
@@ -493,7 +493,7 @@
 }
 .invoice-totals table { font-size: 13px; }
 .invoice-totals td { padding: 4px 16px 4px 0; color: var(--text-secondary); }
-.invoice-totals td:last-child { text-align: right; padding-right: 0; min-width: 100px; color: var(--text); font-weight: var(--font-weight-medium); }
+.invoice-totals td:last-child { text-align: end; padding-inline-end: 0; min-width: 100px; color: var(--text); font-weight: var(--font-weight-medium); }
 .invoice-totals tr.grand td {
   border-top: 2px solid var(--border-color);
   padding-top: 8px;
@@ -550,7 +550,7 @@
   background: var(--bg-surface);
   box-shadow: 0 0 0 3px var(--primary-lt);
 }
-.line-row input[type="number"] { text-align: right; -moz-appearance: textfield; }
+.line-row input[type="number"] { text-align: end; -moz-appearance: textfield; }
 .line-row input[type="number"]::-webkit-outer-spin-button,
 .line-row input[type="number"]::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
 .line-row .desc-wrap input.desc-sub {
@@ -559,7 +559,7 @@
   margin-top: 2px;
 }
 .line-row .amount {
-  text-align: right;
+  text-align: end;
   font-weight: var(--font-weight-medium);
   color: var(--text);
 }
@@ -603,7 +603,7 @@
   padding: 1px 6px;
   font: inherit;
   font-size: 12.5px;
-  text-align: right;
+  text-align: end;
   border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   background: var(--bg-surface);
@@ -628,7 +628,7 @@
 .invoice-payment-status::before {
   content: '';
   position: absolute;
-  left: 32px; right: 32px; top: 28px;
+  inset-inline-start: 32px; inset-inline-end: 32px; top: 28px;
   height: 2px;
   background: var(--border-color);
   z-index: 0;
@@ -709,9 +709,9 @@
   border: 2px solid var(--bg-surface);
   display: flex; align-items: center; justify-content: center;
   font-size: 9px; font-weight: 600; color: white;
-  margin-left: -4px;
+  margin-inline-start: -4px;
 }
-.project-card .avatars .av:first-child { margin-left: 0; }
+.project-card .avatars .av:first-child { margin-inline-start: 0; }
 
 // ────────────────────────
 //  PRODUCT CARD (e-commerce)
@@ -741,7 +741,7 @@
 .product-thumb svg { display: block; width: 100%; height: 100%; }
 .product-thumb .product-badge {
   position: absolute;
-  top: 8px; left: 8px;
+  top: 8px; inset-inline-start: 8px;
 }
 .product-info { padding: 12px; }
 .product-info .name { font-size: 13px; font-weight: var(--font-weight-medium); color: var(--text); margin-bottom: 2px; }
@@ -1068,7 +1068,7 @@ button.project-card {
   appearance: none;
   border: 1px solid var(--border-color);
   background: var(--bg-surface);
-  text-align: left;
+  text-align: start;
   font: inherit;
   color: inherit;
   cursor: pointer;
@@ -1081,8 +1081,8 @@ button.project-card:hover { border-color: var(--primary); }
 // ────────────────────────
 .page-fixed-footer .footer {
   position: fixed;
-  left: var(--sidebar-w);
-  right: 0;
+  inset-inline-start: var(--sidebar-w);
+  inset-inline-end: 0;
   bottom: 0;
   background: var(--bg-surface);
   border-top: 1px solid var(--border-color);
@@ -1090,7 +1090,7 @@ button.project-card:hover { border-color: var(--primary); }
 }
 .page-fixed-footer .page-wrapper { padding-bottom: 80px; }
 @media (max-width: 768px) {
-  .page-fixed-footer .footer { left: 0; }
+  .page-fixed-footer .footer { inset-inline-start: 0; }
 }
 
 // ────────────────────────
@@ -1238,8 +1238,8 @@ button.project-card:hover { border-color: var(--primary); }
 }
 .media-tile .meta {
   position: absolute;
-  left: 0;
-  right: 0;
+  inset-inline-start: 0;
+  inset-inline-end: 0;
   bottom: 0;
   padding: 8px 10px;
   background: linear-gradient(transparent, rgba(0, 0, 0, 0.55));
@@ -1272,7 +1272,7 @@ button.project-card:hover { border-color: var(--primary); }
   content: 'Most popular';
   position: absolute;
   top: -10px;
-  right: 16px;
+  inset-inline-end: 16px;
   background: var(--primary);
   color: white;
   font-size: 10px;
@@ -1300,7 +1300,7 @@ button.project-card:hover { border-color: var(--primary); }
   font-size: 12px;
   color: var(--text-muted);
   font-weight: 400;
-  margin-left: 4px;
+  margin-inline-start: 4px;
 }
 .pricing-tier .desc { font-size: 12.5px; color: var(--text-muted); line-height: 1.5; }
 .pricing-tier ul {
@@ -1366,12 +1366,12 @@ button.project-card:hover { border-color: var(--primary); }
 .landing-nav nav {
   display: flex;
   gap: var(--space-5);
-  margin-left: 32px;
+  margin-inline-start: 32px;
   font-size: 13px;
 }
 .landing-nav nav a { color: var(--text-secondary); }
 .landing-nav nav a:hover { color: var(--text); text-decoration: none; }
-.landing-nav .cta { margin-left: auto; display: flex; gap: var(--space-2); }
+.landing-nav .cta { margin-inline-start: auto; display: flex; gap: var(--space-2); }
 
 .hero {
   padding: 80px 32px 60px;
@@ -1488,7 +1488,7 @@ button.project-card:hover { border-color: var(--primary); }
   .breadcrumb,
   .card-opt-btn { display: none !important; }
 
-  .main { margin-left: 0 !important; padding: 0 !important; }
+  .main { margin-inline-start: 0 !important; padding: 0 !important; }
   .page-wrapper { padding: 0 !important; max-width: none !important; }
   .card,
   .invoice {

--- a/src/scss/v4/_rtl.scss
+++ b/src/scss/v4/_rtl.scss
@@ -1,0 +1,100 @@
+// RTL overrides.
+//
+// The bulk of right-to-left support comes from logical properties
+// (margin-inline-*, padding-inline-*, inset-inline-*, border-inline-*,
+// text-align: start/end) used throughout the other partials — those flip on
+// their own and need nothing here.
+//
+// This file covers only what has no logical equivalent:
+//   1. translateX() — transforms are physical by definition
+//   2. background-position — no logical keyword with usable support
+//   3. box-shadow offsets — physical x/y
+//   4. Chevrons that point along the inline axis
+//
+// Anything centred with `left: 50%` + `translateX(-50%)` is deliberately NOT
+// here: that pattern is direction-neutral and already correct in both modes.
+
+// ---------------------------------------------------------------------------
+// 1. Sidebar mobile drawer — slides in from the inline-start edge
+// ---------------------------------------------------------------------------
+@media (max-width: 768px) {
+  [dir='rtl'] .sidebar {
+    transform: translateX(100%);
+  }
+
+  [dir='rtl'] .sidebar.open {
+    transform: translateX(0);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Rail-mode flyout label — nudges away from the rail, so it mirrors
+// ---------------------------------------------------------------------------
+[dir='rtl'] body.sidebar-rail .nav-link[data-rail-label]::after {
+  transform: translateY(-50%) translateX(4px);
+}
+
+[dir='rtl'] body.sidebar-rail .nav-link[data-rail-label]:hover::after,
+[dir='rtl'] body.sidebar-rail .nav-link[data-rail-label]:focus-visible::after {
+  transform: translateY(-50%) translateX(0);
+}
+
+// The rail collapse chevron points along the inline axis.
+[dir='rtl'] body.sidebar-rail .sidebar-toggle svg {
+  transform: rotate(0deg);
+}
+
+[dir='rtl'] .sidebar-toggle svg {
+  transform: rotate(180deg);
+}
+
+// ---------------------------------------------------------------------------
+// 3. Slide-out drawer — default edge is inline-end, `.left` is inline-start
+// ---------------------------------------------------------------------------
+[dir='rtl'] .drawer {
+  transform: translateX(-100%);
+  box-shadow: 10px 0 30px rgba(0, 0, 0, 0.12);
+}
+
+[dir='rtl'] .drawer.open {
+  transform: translateX(0);
+}
+
+[dir='rtl'] .drawer.left {
+  transform: translateX(100%);
+  box-shadow: -10px 0 30px rgba(0, 0, 0, 0.12);
+}
+
+[dir='rtl'] .drawer.left.open {
+  transform: translateX(0);
+}
+
+// ---------------------------------------------------------------------------
+// 4. Switch + toggle knobs travel along the inline axis
+// ---------------------------------------------------------------------------
+[dir='rtl'] .switch input:checked + .track::before,
+[dir='rtl'] .toggle.on::after {
+  transform: translateX(-16px);
+}
+
+// ---------------------------------------------------------------------------
+// 5. Native select arrow — background-position has no logical form
+// ---------------------------------------------------------------------------
+[dir='rtl'] select.input,
+[dir='rtl'] .input select,
+[dir='rtl'] select.form-control {
+  background-position: left 10px center;
+}
+
+// ---------------------------------------------------------------------------
+// 6. Sidebar accordion chevron — points inline-end when closed, down when open
+// ---------------------------------------------------------------------------
+// Only the closed state is mirrored. The open state points *down*, which is
+// direction-neutral, and the base `.nav-tree.open > .nav-toggle .nav-chev`
+// rule (4 classes) already outranks this one (1 attribute + 1 class) — so it
+// keeps winning for open groups without an override here. Adding one is how
+// this got broken the first time: `scaleX(-1) rotate(-90deg)` applies the
+// rotation first and lands on "up".
+[dir='rtl'] .nav-chev {
+  transform: scaleX(-1);
+}

--- a/src/scss/v4/_widgets.scss
+++ b/src/scss/v4/_widgets.scss
@@ -193,7 +193,7 @@
 .visitor-row:last-child { border-bottom: none; }
 .visitor-flag { font-size: 16px; line-height: 1; }
 .visitor-name { flex: 1; color: var(--text); font-weight: var(--font-weight-normal); }
-.visitor-pct { font-weight: var(--font-weight-bold); color: var(--text); min-width: 32px; text-align: right; font-size: 12.5px; }
+.visitor-pct { font-weight: var(--font-weight-bold); color: var(--text); min-width: 32px; text-align: end; font-size: 12.5px; }
 .visitor-bar {
   width: 80px;
   height: 4px;
@@ -289,7 +289,7 @@
   padding: 3px 0;
 }
 .donut-legend-item .dot { width: 8px; height: 8px; border-radius: 2px; flex-shrink: 0; }
-.donut-legend-item .pct { margin-left: auto; font-weight: var(--font-weight-bold); color: var(--text); font-size: 11.5px; }
+.donut-legend-item .pct { margin-inline-start: auto; font-weight: var(--font-weight-bold); color: var(--text); font-size: 11.5px; }
 
 // ────────────────────────
 //  APP VERSIONS (progress)
@@ -301,7 +301,7 @@
 .version-label { font-size: 12.5px; color: var(--text-secondary); width: 48px; font-weight: var(--font-weight-medium); }
 .version-bar { flex: 1; height: 4px; background: var(--border-color-light); border-radius: 2px; overflow: hidden; }
 .version-bar .fill { height: 100%; border-radius: 2px; }
-.version-pct { font-size: 12px; color: var(--text-muted); width: 30px; text-align: right; font-weight: var(--font-weight-medium); }
+.version-pct { font-size: 12px; color: var(--text-muted); width: 30px; text-align: end; font-weight: var(--font-weight-medium); }
 
 // ────────────────────────
 //  STORAGE WIDGET
@@ -325,7 +325,7 @@
   font-size: 12px; color: var(--text-secondary);
 }
 .storage-legend-item .dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
-.storage-legend-item .val { margin-left: auto; font-weight: var(--font-weight-medium); color: var(--text); }
+.storage-legend-item .val { margin-inline-start: auto; font-weight: var(--font-weight-medium); color: var(--text); }
 
 // ────────────────────────
 //  PROFILE COMPLETION

--- a/src/scss/v4/main.scss
+++ b/src/scss/v4/main.scss
@@ -10,3 +10,6 @@
 @use "datatable";
 @use "auth";
 @use "apps";
+// Last: RTL overrides only fix what logical properties can't express
+// (transforms, background-position, box-shadow), so they must win the cascade.
+@use "rtl";

--- a/vite.config.js
+++ b/vite.config.js
@@ -100,9 +100,10 @@ function shellInjectionPlugin() {
           out = out.replace(/<\/head>/i, `${seo}\n</head>`);
         }
 
-        // Pre-paint theme script: read stored theme and apply data-theme to <html>
-        // before the body renders so dark mode never flashes light.
-        const prePaint = `<script>(function(){try{var t=localStorage.getItem('theme');var d=window.matchMedia('(prefers-color-scheme: dark)').matches;var theme=t||(d?'dark':'light');document.documentElement.setAttribute('data-theme',theme);}catch(e){}})();</script>`;
+        // Pre-paint theme + direction script: read stored theme and text
+        // direction and apply them to <html> before the body renders, so
+        // neither dark mode nor RTL flashes the wrong way round.
+        const prePaint = `<script>(function(){try{var t=localStorage.getItem('theme');var d=window.matchMedia('(prefers-color-scheme: dark)').matches;var theme=t||(d?'dark':'light');document.documentElement.setAttribute('data-theme',theme);var dir=localStorage.getItem('dir');if(dir==='rtl'||dir==='ltr'){document.documentElement.setAttribute('dir',dir);}}catch(e){}})();</script>`;
         out = out.replace(/<\/head>/i, `${prePaint}\n</head>`);
 
         // Admin-shell injection only fires for pages with body[data-shell="admin"].


### PR DESCRIPTION
Ships the roadmap item **"RTL support (logical-properties pass)"**. Arabic, Hebrew, Persian and Urdu layouts now work from `<html dir="rtl">` alone.

## Approach

Converted **151 direction-sensitive declarations** across the SCSS to logical equivalents:

| Physical | Logical | Count |
|---|---|---|
| `left:` / `right:` | `inset-inline-start` / `-end` | 48 |
| `margin-left` / `-right` | `margin-inline-start` / `-end` | 35 |
| `text-align: left` / `right` | `text-align: start` / `end` | 26 |
| `border-left` / `-right` | `border-inline-start` / `-end` | 19 |
| `padding-left` / `-right` | `padding-inline-start` / `-end` | 13 |
| corner radii | `border-start-start-radius` etc. | 10 |

No mirrored stylesheet, no build-time flipping step — one rule set serves both directions.

`_rtl.scss` covers only what has **no** logical form: `translateX` (sidebar drawer, slide-out drawer, switch/toggle knobs, rail flyout label), the select arrow's `background-position`, the drawer's `box-shadow` offsets, and chevrons pointing along the inline axis.

## Two things deliberately left physical

Converting these *breaks* RTL, so they're called out in the code and in the docs:

1. **`left: 50%` + `translateX(-50%)`** (4 sites) — direction-neutral centring. The offset would flip while the transform wouldn't, throwing the element off-centre.
2. **Chevrons that point *down* when open** — vertical, so direction-neutral. Only the closed inline-axis state is mirrored. I got this wrong on the first pass (`scaleX(-1) rotate(-90deg)` applies the rotation first and lands on "up"); the fix was to delete the override and let the base rule win on specificity.

## Verification

In an LTR document, logical properties compute **identically** to the physical ones they replace — so the whole conversion is gated on that invariant. 12 representative pages screenshotted before and after and compared by hash:

```
=== FINAL LTR GATE ===
  ✓ 12/12 pages pixel-identical to pre-RTL baseline
```

(The harness was itself checked for determinism first — two identical runs produce identical hashes — otherwise the gate would be meaningless.)

RTL checked visually across dashboard, inbox, forms and tables. The two transform-dependent cases were asserted via computed style rather than eyeballed:

```
toggle knob   ltr: matrix(…, 16, 0)   rtl: matrix(…, -16, 0)
select arrow  ltr: calc(100% - 10px)  rtl: 10px
```

Residual audit: **0** physical `margin`/`padding`/`border`/`text-align` left in the SCSS; the only 4 remaining physical offsets are the intended centring cases.

## Also

- New [`docs/rtl.md`](docs/rtl.md) — how to enable it, how to write new styles that work in both directions, and what deliberately isn't mirrored (charts, and Latin text in an RTL container, which reorders per the Unicode bidi algorithm — correct behaviour, not a layout bug)
- Direction persists in `localStorage` under `dir`, applied by the existing pre-paint script alongside the theme, so RTL never flashes the wrong way round
- RTL moved from "Roadmap" to "Features" in both READMEs; added to `llms.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)