### PR TITLE
Syntax-highlight the playground's HTML samples, playground-only

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,6 +28,7 @@ export default [
         getComputedStyle: 'readonly',
         CustomEvent: 'readonly',
         IntersectionObserver: 'readonly',
+        NodeFilter: 'readonly',
         ResizeObserver: 'readonly',
         MutationObserver: 'readonly',
         URL: 'readonly',

--- a/production/playground.html
+++ b/production/playground.html
@@ -544,6 +544,11 @@ container.innerHTML = `&lt;ul class="activity-list"&gt;${html}&lt;/ul&gt;`;</cod
 import { showToast } from '/src/v4/toast.js';
 import { statTile, statusBadge, customerCell, activityItem, visitorRow, emptyState, escapeHtml } from '/src/v4/markup.js';
 
+// Syntax highlighting is playground-only: dynamically imported so it lands in
+// its own chunk and adds nothing to the bundle every other page loads.
+const hl = import('/src/v4/highlight.js');
+const paint = (el) => hl.then((m) => m.paintBlock(el)).catch(() => {});
+
 // Build a code-source row under each [data-source] card.
 function indent(html) {
   // Lightly format the HTML for display: collapse whitespace + indent.
@@ -583,6 +588,7 @@ document.querySelectorAll('[data-source]').forEach((card) => {
   const resetBtn = block.querySelector('.pg-reset');
   codeEl.textContent = code;
   card.appendChild(block);
+  paint(codeEl);
 
   // Live edit: debounce 250ms, set preview.innerHTML from textContent.
   // Browser auto-corrects malformed HTML — we don't try to validate.
@@ -592,6 +598,7 @@ document.querySelectorAll('[data-source]').forEach((card) => {
     editTimer = setTimeout(() => {
       preview.innerHTML = codeEl.textContent;
       resetBtn.hidden = false;
+      paint(codeEl);
     }, 250);
   });
 
@@ -599,6 +606,7 @@ document.querySelectorAll('[data-source]').forEach((card) => {
     preview.innerHTML = originalHtml;
     codeEl.textContent = indent(originalHtml);
     resetBtn.hidden = true;
+    paint(codeEl);
   });
 
   block.querySelector('.pg-copy').addEventListener('click', async () => {
@@ -610,6 +618,9 @@ document.querySelectorAll('[data-source]').forEach((card) => {
     }
   });
 });
+
+// Static (non-editable) samples elsewhere on the page.
+hl.then((m) => document.querySelectorAll('.pg-code:not(.pg-code-edit)').forEach(m.paintBlock)).catch(() => {});
 
 // Scrollspy for the left rail.
 const links = [...document.querySelectorAll('.pg-nav-link')];
@@ -898,6 +909,10 @@ if (emptyHost) {
   color: var(--text-muted);
 }
 .pg-code {
+  /* Source code always reads left-to-right, even when the page is dir="rtl" —
+     otherwise the lines right-align and the bracket order reads backwards. */
+  direction: ltr;
+  text-align: left;
   margin: 0;
   padding: 14px 16px;
   font-family: var(--font-mono);
@@ -920,6 +935,25 @@ if (emptyHost) {
   background: var(--bg-surface-secondary);
   box-shadow: inset 3px 0 0 var(--primary);
 }
+/* Syntax highlighting tokens — scoped to this page so the shared stylesheet
+   (loaded on all 58 pages) stays exactly the size it was. */
+.pg-code {
+  --tok-tag: #1f6f9f;
+  --tok-attr: #7a45b8;
+  --tok-value: #167f57;
+  --tok-comment: var(--text-muted);
+  --tok-punct: var(--text-disabled);
+}
+[data-theme="dark"] .pg-code {
+  --tok-tag: #79b8e3;
+  --tok-attr: #c4a2f5;
+  --tok-value: #5ac9a0;
+}
+.pg-code .tok-tag { color: var(--tok-tag); }
+.pg-code .tok-attr { color: var(--tok-attr); }
+.pg-code .tok-value { color: var(--tok-value); }
+.pg-code .tok-comment { color: var(--tok-comment); font-style: italic; }
+.pg-code .tok-punct { color: var(--tok-punct); }
 .pg-edit-hint {
   font-weight: 400;
   text-transform: none;

--- a/src/v4/highlight.js
+++ b/src/v4/highlight.js
@@ -1,0 +1,139 @@
+// Syntax highlighting for the component playground's HTML snippets.
+//
+// Loaded ONLY by production/playground.html, via a dynamic import, so it lands
+// in its own chunk and costs every other page nothing. Its colours live in that
+// page's own <style> block for the same reason.
+//
+// Purpose-built rather than a library: the playground only ever shows HTML, and
+// a general highlighter (Prism, highlight.js, Shiki) would mean a new production
+// dependency and a far larger chunk for grammars this page never uses.
+//
+// The code blocks are `contenteditable` and drive a live preview from
+// `textContent`, so highlighting must be invisible to the rest of the page:
+// injecting <span> wrappers leaves `textContent` byte-identical, which keeps
+// the preview, the Copy button, and Reset all working untouched.
+
+const ENTITIES = { '&': '&amp;', '<': '&lt;', '>': '&gt;' };
+const esc = s => s.replace(/[&<>]/g, c => ENTITIES[c]);
+const wrap = (cls, text) => `<span class="tok-${cls}">${esc(text)}</span>`;
+
+// Attributes, bare attributes, whitespace, then any single leftover character.
+const ATTR_RE =
+  /([a-zA-Z_:][-\w:.]*)(\s*=\s*)("[^"]*"|'[^']*'|[^\s"'>]+)|([a-zA-Z_:][-\w:.]*)|(\s+)|([\s\S])/g;
+
+function highlightTag(tag) {
+  const name = /^<\/?([a-zA-Z][-\w:.]*)/.exec(tag);
+  if (!name) {
+    return esc(tag);
+  }
+
+  const openLen = name[0].length - name[1].length; // "<" or "</"
+  let out = wrap('punct', tag.slice(0, openLen)) + wrap('tag', name[1]);
+
+  ATTR_RE.lastIndex = 0;
+  const rest = tag.slice(name[0].length);
+  let m;
+  while ((m = ATTR_RE.exec(rest)) !== null) {
+    const [, attr, eq, value, bare, space, other] = m;
+    if (attr) {
+      out += wrap('attr', attr) + wrap('punct', eq) + wrap('value', value);
+    } else if (bare) {
+      out += wrap('attr', bare);
+    } else if (space) {
+      out += esc(space);
+    } else {
+      out += other === '>' || other === '/' ? wrap('punct', other) : esc(other);
+    }
+  }
+  return out;
+}
+
+/** Turn an HTML source string into highlighted markup. */
+export function highlightHtml(source) {
+  let out = '';
+  let i = 0;
+  while (i < source.length) {
+    if (source.startsWith('<!--', i)) {
+      const end = source.indexOf('-->', i + 4);
+      const stop = end === -1 ? source.length : end + 3;
+      out += wrap('comment', source.slice(i, stop));
+      i = stop;
+    } else if (source[i] === '<') {
+      const end = source.indexOf('>', i);
+      const stop = end === -1 ? source.length : end + 1;
+      out += highlightTag(source.slice(i, stop));
+      i = stop;
+    } else {
+      const next = source.indexOf('<', i);
+      const stop = next === -1 ? source.length : next;
+      out += esc(source.slice(i, stop));
+      i = stop;
+    }
+  }
+  return out;
+}
+
+// --- caret preservation -----------------------------------------------------
+// Repainting innerHTML destroys the selection, so record the caret as a plain
+// text offset first and walk the new text nodes to put it back. Offsets are
+// measured on text, which the repaint leaves identical.
+
+function caretOffset(root) {
+  const sel = window.getSelection();
+  if (!sel || !sel.rangeCount) {
+    return null;
+  }
+  const range = sel.getRangeAt(0);
+  if (!root.contains(range.startContainer)) {
+    return null;
+  }
+  const probe = range.cloneRange();
+  probe.selectNodeContents(root);
+  probe.setEnd(range.startContainer, range.startOffset);
+  return probe.toString().length;
+}
+
+function restoreCaret(root, offset) {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const range = document.createRange();
+  let seen = 0;
+  let node;
+  while ((node = walker.nextNode()) !== null) {
+    const len = node.nodeValue.length;
+    if (seen + len >= offset) {
+      range.setStart(node, Math.max(0, offset - seen));
+      range.collapse(true);
+      const sel = window.getSelection();
+      sel.removeAllRanges();
+      sel.addRange(range);
+      return;
+    }
+    seen += len;
+  }
+  range.selectNodeContents(root);
+  range.collapse(false);
+  const sel = window.getSelection();
+  sel.removeAllRanges();
+  sel.addRange(range);
+}
+
+/**
+ * Repaint one block from its own textContent. Safe to call while the block has
+ * focus — the caret is restored to the same text offset afterwards.
+ */
+export function paintBlock(el) {
+  if (!el) {
+    return;
+  }
+  const focused = document.activeElement === el;
+  const offset = focused ? caretOffset(el) : null;
+  el.innerHTML = highlightHtml(el.textContent);
+  if (offset !== null) {
+    restoreCaret(el, offset);
+  }
+}
+
+/** Paint every matching block. Idempotent — repainting is a no-op visually. */
+export function highlightAll(selector = '.pg-code') {
+  document.querySelectorAll(selector).forEach(paintBlock);
+}


### PR DESCRIPTION
The [playground](https://preview.colorlib.com/theme/gentelella/production/playground.html) shows each component beside its exact HTML, but that source rendered as flat monochrome text. This colours tags, attributes, values and comments — **without adding a byte to any other page.**

## Scoping

That was the whole requirement, so it drove both decisions:

- The highlighter is **dynamically imported** from `playground.html`, so Vite emits it as its own chunk that only that page requests.
- Its token colours go in the page's **existing `<style>` block**, not `main.scss` — that's one 157 KB stylesheet served on all 58 pages.

```
main-v4 JS    70278 bytes ->  70278   UNCHANGED
main-v4 CSS  156794 bytes -> 156794   UNCHANGED
highlight chunk (playground-only)      1808 bytes
```

Confirmed by loading six other pages and counting requests for the chunk:

```
index  0 · inbox 0 · tables 0 · form 0 · kanban 0 · profile 0
```

## Why not Prism / highlight.js / Shiki

The playground only ever shows **HTML**. A general highlighter would mean a new production dependency (the repo has 3) and a much larger chunk carrying grammars this page never uses — against the template's "vanilla and small" pitch. The tokenizer here is ~90 lines and handles exactly the one language in play.

## The contenteditable constraint

The blocks are `contenteditable` and drive a live preview from `textContent`, so highlighting had to be invisible to everything else:

- Injecting `<span>` wrappers leaves `textContent` **byte-identical** — the preview, the Copy button and Reset keep working untouched, no changes needed to any of them.
- Repaints record the caret as a plain-text offset and walk the new text nodes to restore it, so highlighting while you type doesn't move the cursor. Verified: caret at offset 7, type `XY`, caret lands at 9 with highlighting intact.

## Drive-by fix

Pins `.pg-code` to `direction: ltr`. RTL support landed in #1005 and code blocks were inheriting it — source right-aligned with the bracket order reading backwards. The surrounding chrome (label, Copy/Reset) still mirrors correctly.

| | before | after |
|---|---|---|
| RTL page | code right-aligned, unreadable | code LTR, chrome mirrored |

## Verification

Live edit still updates the preview · Copy yields plain text with no span markup · Reset restores and repaints · caret preserved across repaint · light + dark + RTL checked visually · no page errors · `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)