### PR TITLE
Ship two roadmap items: sitemap.xml generator and JSON-LD

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Built for 2026 by [Colorlib](https://colorlib.com). **[Live demo →](https://pr
 
 The original Gentelella has been a free Bootstrap admin template since 2014 — **3M+ downloads**, [21k+ GitHub stars](https://github.com/ColorlibHQ/gentelella). v4 is a ground-up redesign:
 
-- **No Bootstrap, no jQuery** — vanilla JavaScript + SCSS. ~178 MB `node_modules` (down from ~600 MB on v2).
+- **No Bootstrap, no jQuery** — vanilla JavaScript + SCSS. ~165 MB `node_modules` (down from ~600 MB on v2).
 - **Vite 8 build system** — instant HMR, multi-page app with auto-discovered entry points, hashed assets.
 - **Light + dark mode** with `prefers-color-scheme` detection and pre-paint script (no flash of incorrect theme).
 - **PWA-ready** — installable on desktop and mobile, offline shell, service worker.
@@ -168,7 +168,7 @@ Need advanced features, dedicated support, and production-ready code? Explore ou
 - **Inter** font from Google Fonts
 - **Playwright** (devDep) — for the screenshot pipeline and smoke tests
 
-3 production deps, 10 dev deps, **~178 MB `node_modules`** (was ~600 MB on the old Gentelella).
+3 production deps, 10 dev deps, **~165 MB `node_modules`** (was ~600 MB on the old Gentelella).
 
 ## Documentation
 
@@ -391,6 +391,8 @@ Every page is built with SEO in mind:
 - **Per-page `<meta description>`** auto-derived from the breadcrumb
 - **Open Graph + Twitter Card** tags injected at build time
 - **PWA manifest** + theme-color (light + dark variants)
+- **`sitemap.xml`** generated at build time from the discovered pages, excluding auth/error screens (opt in with `SITE_URL=https://example.com/ npm run build`)
+- **JSON-LD structured data** on the landing page — `SoftwareApplication` plus a `FAQPage` parsed from the page's own FAQ at build time, so the markup can't drift from the visible answers
 - **Pre-paint theme script** — eliminates flash of incorrect theme on load
 - **Skip-to-content link** + ARIA landmarks for screen reader navigation
 - **`Cache-Control`-aware deploy** ([`scripts/deploy-preview.sh`](scripts/deploy-preview.sh)) — long-cache for hashed assets, short-cache for HTML, no-cache for service worker
@@ -423,8 +425,6 @@ Shipped in `4.0.0` — full list in [`changelog.md`](changelog.md). Still planne
 
 - **Image optimization** — compress `public/images/*.jpg` and ship AVIF + JPG fallback
 - **Lighthouse audit** + tuning to 95+ Performance / 100 A11y / 100 SEO / 100 PWA
-- **JSON-LD structured data** on landing + marketing pages
-- **`sitemap.xml`** generator (auto-built from `production/*.html`)
 - **Per-page chart-type tree-shaking** to slim the ECharts vendor chunk
 - **i18n extraction pattern**
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,7 +47,7 @@
 
 初代 Gentelella 自 2014 年起就是一套免费的 Bootstrap 后台模板，累计**下载量超过 300 万次**，[GitHub Star 超过 21k](https://github.com/ColorlibHQ/gentelella)。v4 是一次彻底的重构：
 
-- **不依赖 Bootstrap，不依赖 jQuery** — 纯原生 JavaScript + SCSS。`node_modules` 约 178 MB（v2 时约为 600 MB）。
+- **不依赖 Bootstrap，不依赖 jQuery** — 纯原生 JavaScript + SCSS。`node_modules` 约 165 MB（v2 时约为 600 MB）。
 - **Vite 8 构建系统** — 即时 HMR、多页面应用、入口自动发现、资源文件名哈希。
 - **浅色 + 深色主题**，自动识别 `prefers-color-scheme`，并通过首屏前置脚本消除主题闪烁。
 - **PWA 就绪** — 可安装到桌面和移动端，支持离线外壳与 Service Worker。
@@ -109,7 +109,7 @@
 - 来自 Google Fonts 的 **Inter** 字体
 - **Playwright**（开发依赖）— 用于截图流水线和冒烟测试
 
-3 个生产依赖，10 个开发依赖，`node_modules` 约 **178 MB**（旧版 Gentelella 约 600 MB）。
+3 个生产依赖，10 个开发依赖，`node_modules` 约 **165 MB**（旧版 Gentelella 约 600 MB）。
 
 ## 文档
 
@@ -332,6 +332,8 @@ npm run new -- reports --title "Reports" --pretitle "Admin" \
 - **逐页 `<meta description>`**，自动由面包屑推导
 - **Open Graph + Twitter Card** 标签在构建时注入
 - **PWA manifest** 与 theme-color（浅色/深色两套）
+- 构建时依据已发现的页面生成 **`sitemap.xml`**，自动排除登录与错误页（通过 `SITE_URL=https://example.com/ npm run build` 启用）
+- 落地页的 **JSON-LD 结构化数据** —— `SoftwareApplication`，以及构建时从页面自身 FAQ 解析出的 `FAQPage`，确保结构化数据与可见内容始终一致
 - **主题前置脚本** — 消除加载时的主题闪烁
 - **跳转到主内容链接** + ARIA 地标，便于屏幕阅读器导航
 - **区分缓存策略的部署脚本**（[`scripts/deploy-preview.sh`](scripts/deploy-preview.sh)）— 哈希资源长缓存，HTML 短缓存，Service Worker 不缓存
@@ -364,8 +366,6 @@ npm run new -- reports --title "Reports" --pretitle "Admin" \
 
 - **图片优化** — 压缩 `public/images/*.jpg`，并提供 AVIF + JPG 回退
 - **Lighthouse 审计**与调优，目标 95+ 性能 / 100 无障碍 / 100 SEO / 100 PWA
-- 落地页与营销页的 **JSON-LD 结构化数据**
-- **`sitemap.xml`** 生成器（依据 `production/*.html` 自动生成）
 - **按页面对图表类型做 tree-shaking**，进一步精简 ECharts 依赖块
 - **i18n 文案提取方案**
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gentelella",
   "version": "4.1.1",
   "type": "module",
-  "description": "Gentelella v4 — free admin template. 60 pages, 20 chart variants, fully interactive inbox & kanban, live theme generator, component playground, PWA-ready. Vite 8, vanilla JS, no Bootstrap, no jQuery.",
+  "description": "Gentelella v4 — free admin template. 58 pages, 20 chart variants, fully interactive inbox & kanban, live theme generator, component playground, PWA-ready. Vite 8, vanilla JS, no Bootstrap, no jQuery.",
   "scripts": {
     "dev": "vite --clearScreen false",
     "build": "NODE_ENV=production vite build",

--- a/production/landing.html
+++ b/production/landing.html
@@ -278,7 +278,7 @@
     </details>
     <details style="background:var(--bg-surface);border:1px solid var(--border-color);border-radius:var(--radius);padding:18px 20px">
       <summary style="font-size:14px;font-weight:600;color:var(--text);cursor:pointer;list-style:none;display:flex;justify-content:space-between;align-items:center">What changed in v4? <span style="color:var(--text-muted)">+</span></summary>
-      <div style="font-size:13px;color:var(--text-secondary);line-height:1.6;margin-top:12px;padding-top:12px;border-top:1px solid var(--border-color-light)">Bootstrap and jQuery are gone. The design system is custom SCSS. ECharts replaced Chart.js. DataTables replaced jQuery DataTables. node_modules dropped from ~600 MB to 138 MB. See the <a href="https://github.com/ColorlibHQ/gentelella/blob/master/changelog.md">changelog</a> for the full diff.</div>
+      <div style="font-size:13px;color:var(--text-secondary);line-height:1.6;margin-top:12px;padding-top:12px;border-top:1px solid var(--border-color-light)">Bootstrap and jQuery are gone. The design system is custom SCSS. ECharts replaced Chart.js. DataTables replaced jQuery DataTables. node_modules dropped from ~600 MB to ~165 MB. See the <a href="https://github.com/ColorlibHQ/gentelella/blob/master/changelog.md">changelog</a> for the full diff.</div>
     </details>
     <details style="background:var(--bg-surface);border:1px solid var(--border-color);border-radius:var(--radius);padding:18px 20px">
       <summary style="font-size:14px;font-weight:600;color:var(--text);cursor:pointer;list-style:none;display:flex;justify-content:space-between;align-items:center">Where can I get help? <span style="color:var(--text-muted)">+</span></summary>

--- a/scripts/deploy-preview.sh
+++ b/scripts/deploy-preview.sh
@@ -28,7 +28,8 @@ SLUG="${PREVIEW_SLUG:-gentelella}"
 BUCKET="r2pro:colorlib-preview/theme/$SLUG"
 
 echo "→ Building with BASE_PATH=/theme/$SLUG/"
-BASE_PATH="/theme/$SLUG/" npm run build
+# SITE_URL makes the build emit sitemap.xml with absolute URLs for this host.
+BASE_PATH="/theme/$SLUG/" SITE_URL="https://preview.colorlib.com/theme/$SLUG/" npm run build
 
 # Strip dev artifacts.
 rm -f dist/stats.html
@@ -58,6 +59,7 @@ echo "→ Pass 2/3: re-upload HTML pages + llms.txt with short cache"
 rclone copy dist/ "$BUCKET/" \
   --include "*.html" \
   --include "llms.txt" \
+  --include "sitemap.xml" \
   --header-upload "$SHORT_CACHE" \
   --ignore-times \
   --progress

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite';
 import { visualizer } from 'rollup-plugin-visualizer';
 import { renderShell, parseShellAttrs } from './src/v4/shell-render.js';
-import { readdirSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 // Auto-detect every entry HTML in production/ and register it as a Rollup
@@ -19,6 +19,124 @@ function discoverEntries() {
     out[stem] = `production/${file}`;
   }
   return out;
+}
+
+// JSON-LD structured data for the marketing landing page.
+//
+// The FAQ entries are parsed out of the page's own <details>/<summary> markup
+// at build time rather than hand-maintained here. Google requires FAQ markup to
+// match the visible answers exactly, and a hand-copied block silently drifts the
+// first time someone edits the page — this can't.
+//
+// Deliberately NO aggregateRating/Review: the testimonials on the landing page
+// are placeholder demo content, and emitting review markup for invented praise
+// is both dishonest and a structured-data violation.
+function structuredDataPlugin() {
+  const pkg = JSON.parse(readFileSync(resolve(import.meta.dirname, 'package.json'), 'utf8'));
+  const SITE = 'https://gentelella.colorlib.com/';
+  const ENTITIES = {
+    '&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"', '&#39;': "'",
+    '&mdash;': '\u2014', '&ndash;': '\u2013', '&nbsp;': ' ', '&hellip;': '\u2026'
+  };
+  const plain = (frag) =>
+    frag
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/&[a-z#0-9]+;/gi, (e) => ENTITIES[e] ?? e)
+      .replace(/\s+/g, ' ')
+      .trim();
+
+  return {
+    name: 'gentelella-structured-data',
+    transformIndexHtml: {
+      order: 'post',
+      handler(html, ctx) {
+        if (!/landing\.html$/.test(ctx?.filename || ctx?.path || '')) return html;
+
+        const faq = [];
+        const blocks = /<details[^>]*>([\s\S]*?)<\/details>/g;
+        let block;
+        while ((block = blocks.exec(html)) !== null) {
+          const summary = /<summary[^>]*>([\s\S]*?)<\/summary>/.exec(block[1]);
+          if (!summary) continue;
+          // Trailing "+" is the open/close affordance, not part of the question.
+          const question = plain(summary[1]).replace(/\s*\+$/, '');
+          const answer = plain(block[1].slice(summary.index + summary[0].length));
+          if (question && answer) {
+            faq.push({
+              '@type': 'Question',
+              name: question,
+              acceptedAnswer: { '@type': 'Answer', text: answer }
+            });
+          }
+        }
+
+        const graph = [
+          {
+            '@type': 'SoftwareApplication',
+            name: 'Gentelella',
+            applicationCategory: 'DeveloperApplication',
+            operatingSystem: 'Any',
+            softwareVersion: pkg.version,
+            url: SITE,
+            description: pkg.description,
+            license: 'https://opensource.org/licenses/MIT',
+            offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+            author: { '@type': 'Organization', name: 'Colorlib', url: 'https://colorlib.com' }
+          }
+        ];
+        if (faq.length) graph.push({ '@type': 'FAQPage', mainEntity: faq });
+
+        const json = JSON.stringify({ '@context': 'https://schema.org', '@graph': graph })
+          .replace(/</g, '\\u003c'); // never let a "</script>" escape the block
+        return html.replace(
+          /<\/head>/i,
+          `<script type="application/ld+json">${json}</script>\n</head>`
+        );
+      }
+    }
+  };
+}
+
+// Emit sitemap.xml from the discovered entry pages. Opt-in via SITE_URL,
+// because a sitemap has to carry absolute URLs and guessing the deploy host
+// would ship a file pointing at somewhere the site isn't. No SITE_URL, no
+// sitemap — better than a confidently wrong one.
+//
+//   SITE_URL=https://example.com/ npm run build
+//
+// Pages that shouldn't be indexed (auth, error, and placeholder screens) are
+// excluded — they're real pages in the template, but nobody wants a login
+// form or a 404 mockup as a search result.
+const SITEMAP_EXCLUDE = new Set([
+  'coming_soon', 'forgot_password', 'lock_screen', 'login', 'maintenance',
+  'offline', 'page_403', 'page_404', 'page_500', 'register', 'verify_2fa'
+]);
+
+function sitemapPlugin() {
+  return {
+    name: 'gentelella-sitemap',
+    apply: 'build',
+    generateBundle() {
+      const site = process.env.SITE_URL;
+      if (!site) return;
+      const origin = site.endsWith('/') ? site : `${site}/`;
+      const urls = Object.keys(discoverEntries())
+        .map((stem) => (stem === 'main' ? 'index' : stem))
+        .filter((stem) => !SITEMAP_EXCLUDE.has(stem))
+        .sort()
+        // index.html is the site root; the rest keep their filename.
+        .map((stem) => (stem === 'index' ? origin : `${origin}production/${stem}.html`));
+
+      const body = urls
+        .map((loc) => `  <url><loc>${loc.replace(/&/g, '&amp;')}</loc></url>`)
+        .join('\n');
+      this.emitFile({
+        type: 'asset',
+        fileName: 'sitemap.xml',
+        source: `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${body}\n</urlset>\n`
+      });
+    }
+  };
 }
 
 // Emit a root index.html that forwards to the dashboard. Entry pages all live
@@ -138,7 +256,7 @@ export default defineConfig(({ command }) => ({
   root: '.',
   base: command === 'serve' ? '/' : (process.env.BASE_PATH ?? '/'),
   publicDir: 'public',
-  plugins: [shellInjectionPlugin(), rootRedirectPlugin()],
+  plugins: [shellInjectionPlugin(), rootRedirectPlugin(), sitemapPlugin(), structuredDataPlugin()],
   logLevel: 'info',
   clearScreen: false,
   build: {


### PR DESCRIPTION
Two of the six remaining roadmap items.

## `sitemap.xml` generator

Built from the auto-discovered entries, so it can't drift from the pages that actually exist.

**Opt-in via `SITE_URL`.** A sitemap carries absolute URLs, and guessing the deploy host would ship a file pointing at somewhere the site isn't — so no `SITE_URL`, no sitemap. Better than a confidently wrong one.

```bash
SITE_URL=https://example.com/ npm run build
```

Auth, error and placeholder screens are excluded — they're real pages in the template, but nobody wants a login form or a 404 mockup as a search result. **58 pages → 47 URLs.** Verified: parses as valid XML, all URLs absolute, no duplicates, zero excluded pages present.

`deploy-preview.sh` now sets `SITE_URL` for the preview host and gives `sitemap.xml` the short-cache header alongside the HTML (otherwise pass 1's one-year immutable header would pin a stale copy).

## JSON-LD

`SoftwareApplication` + `FAQPage` on the landing page, injected only there (verified absent from `index` and `playground`).

The FAQ entries are **parsed from the page's own `<details>`/`<summary>` markup at build time** rather than hand-maintained. Google requires FAQ markup to match the visible answers exactly, and a hand-copied block silently drifts the first time someone edits the page. This can't. Six questions extracted, with the trailing `+` toggle affordance stripped from each.

**Deliberately no `aggregateRating` / `Review`.** The landing page's testimonials are placeholder demo content — emitting review markup for invented praise is dishonest and a structured-data violation. Asserted absent in the build check.

## Factual corrections

The page count now feeds the JSON-LD `description` *and* the npm listing, so it had to be right:

| | claimed | actual |
|---|---|---|
| `package.json` description | 60 pages | **58** |
| README `node_modules` | ~178 MB | **~165 MB** |
| landing FAQ `node_modules` | 138 MB | **~165 MB** |

## Not attempted

**Per-page ECharts tree-shaking** — the 1 MB vendor chunk comes from `import('echarts/charts')` pulling the whole barrel and destructuring at runtime, which defeats tree-shaking. Real win available, but it's the riskiest item here and wants its own PR with before/after measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)